### PR TITLE
Partially fixed UI for counter component:

### DIFF
--- a/app_layout/top_bar.go
+++ b/app_layout/top_bar.go
@@ -40,7 +40,6 @@ func (ab *TopBar) Layout(gtx C) D {
 				gtx.Constraints.Constrain(size),
 				globals.Colours["dark-cyan"],
 			)
-
 			return bar
 		}),
 		// This returns a Stacked layout which returns a custom Inset, which will eventually

--- a/apps/counters/components/counter_component.go
+++ b/apps/counters/components/counter_component.go
@@ -1,7 +1,6 @@
 package components
 
 import (
-	"fmt"
 	"gioui-experiment/custom_widgets"
 	"gioui-experiment/globals"
 	"gioui.org/layout"
@@ -36,24 +35,6 @@ func (c *Counter) Layout(th *material.Theme, gtx C) D {
 	}.Layout(
 		gtx,
 
-		// Display the Counter number
-		layout.Flexed(1, func(gtx C) D {
-			currVal := material.H2(th, strconv.FormatInt(globals.Count, 10))
-			if globals.Count < 0 {
-				currVal.Color = globals.Colours["red"]
-			} else if globals.Count > 0 {
-				currVal.Color = globals.Colours["dark-green"]
-			} else {
-				currVal.Color = globals.Colours["grey"]
-			}
-			return layout.Center.Layout(
-				gtx,
-				currVal.Layout,
-			)
-		}),
-
-		globals.SpacerY,
-
 		// Using flex-box on Y-Axis, which contains the 3 buttons
 		// The first child of the Flex layout contains a Rigid layout, in which the 2 buttons are flexed horizontally.
 		// The second child is the reset Button, returned as a layout.Rigid
@@ -87,6 +68,29 @@ func (c *Counter) Layout(th *material.Theme, gtx C) D {
 								}.Layout)
 
 						}),
+						globals.SpacerX,
+
+						// Reset Button
+						layout.Rigid(func(gtx C) D {
+							// if count == reset, disable Reset button
+							if globals.Count == globals.ResetVal {
+								gtx = gtx.Disabled()
+							}
+
+							for range c.resetBtn.Clicks() {
+								globals.Count = globals.ResetVal
+							}
+							return globals.Inset.Layout(
+								gtx,
+								custom_widgets.LabeledIconBtn{
+									Theme:      th,
+									BgColor:    globals.Colours["red"],
+									LabelColor: globals.Colours["white"],
+									Button:     &c.minusBtn,
+									Icon:       globals.MinusIcon,
+									Label:      strconv.FormatInt(globals.CountUnit, 10),
+								}.Layout)
+						}),
 
 						globals.SpacerX,
 
@@ -105,27 +109,10 @@ func (c *Counter) Layout(th *material.Theme, gtx C) D {
 									Button:     &c.plusBtn,
 									Icon:       globals.PlusIcon,
 									Label:      strconv.FormatInt(globals.CountUnit, 10),
-								}.Layout)
-
+								}.Layout,
+							)
 						}),
 					)
-				}),
-
-				globals.SpacerY,
-
-				// Reset Button
-				layout.Rigid(func(gtx C) D {
-					// if count == reset, disable Reset button
-					if globals.Count == globals.ResetVal {
-						gtx = gtx.Disabled()
-					}
-
-					for range c.resetBtn.Clicks() {
-						globals.Count = globals.ResetVal
-					}
-					btn := material.Button(th, &c.resetBtn, fmt.Sprintf("Reset to %d", globals.ResetVal))
-					btn.Background = globals.Colours["blue"]
-					return btn.Layout(gtx)
 				}),
 			)
 		}),

--- a/apps/counters/components/viewer.go
+++ b/apps/counters/components/viewer.go
@@ -1,0 +1,46 @@
+package components
+
+import (
+	"gioui-experiment/globals"
+	"gioui.org/layout"
+	"gioui.org/unit"
+	"gioui.org/widget/material"
+	"image"
+	"strconv"
+)
+
+type View struct{}
+
+func (v *View) Layout(th *material.Theme, gtx C) D {
+	size := image.Pt(gtx.Constraints.Max.X, gtx.Constraints.Max.Y)
+	return layout.Stack{}.Layout(
+		gtx,
+		layout.Expanded(func(gtx C) D {
+			view := globals.ColoredArea(
+				gtx,
+				gtx.Constraints.Constrain(size),
+				globals.Colours["antique-white"],
+			)
+			return view
+		}),
+
+		layout.Stacked(func(gtx C) D {
+			mainVal := material.H3(th, strconv.FormatInt(globals.Count, 10))
+			if globals.Count < 0 {
+				mainVal.Color = globals.Colours["red"]
+			} else if globals.Count > 0 {
+				mainVal.Color = globals.Colours["dark-green"]
+			} else {
+				mainVal.Color = globals.Colours["grey"]
+			}
+
+			return layout.Inset{
+				Top:    unit.Dp(2),
+				Right:  unit.Dp(5),
+				Bottom: unit.Dp(2),
+				Left:   unit.Dp(5),
+			}.Layout(gtx, func(gtx C) D {
+				return mainVal.Layout(gtx)
+			})
+		}))
+}

--- a/apps/geometry/drawing.go
+++ b/apps/geometry/drawing.go
@@ -16,11 +16,16 @@ type (
 	D = layout.Dimensions
 )
 
+type Draw func()
+
 type Geometry struct {
-	color color.NRGBA
+	Color  color.NRGBA
+	coords []float32
+	Draw   func(C, []float32, color.NRGBA) D
+	drawer Draw
 }
 
-func (g Geometry) FRect(gtx C, geom []float32, color color.NRGBA) D {
+func (G Geometry) FRect(gtx C, geom []float32, color color.NRGBA) D {
 	defer op.Save(gtx.Ops).Load()
 	coords := f32.Rect(geom[0], geom[1], geom[2], geom[3])
 	clip.RRect{Rect: coords}.Add(gtx.Ops)
@@ -31,7 +36,7 @@ func (g Geometry) FRect(gtx C, geom []float32, color color.NRGBA) D {
 	}
 }
 
-func (g Geometry) Rect(gtx C, size image.Point, color color.NRGBA) D {
+func (G Geometry) Rect(gtx C, size image.Point, color color.NRGBA) D {
 	defer op.Save(gtx.Ops).Load()
 	clip.Rect{Max: size}.Add(gtx.Ops)
 	paint.ColorOp{Color: color}.Add(gtx.Ops)
@@ -41,16 +46,16 @@ func (g Geometry) Rect(gtx C, size image.Point, color color.NRGBA) D {
 	}
 }
 
-func (g *Geometry) Layout(gtx C) D {
-	geometry := []float32{float32(gtx.Constraints.Max.X), float32(gtx.Constraints.Max.Y), 0, 0}
+func (G *Geometry) Layout(gtx C) D {
+	coords := []float32{float32(gtx.Constraints.Max.X), float32(gtx.Constraints.Max.Y), 0, 0}
 	return layout.Stack{}.Layout(
 		gtx,
 		layout.Expanded(func(gtx C) D {
-			screen := g.FRect(gtx, geometry, globals.Colours["antique-white"])
+			screen := G.FRect(gtx, coords, globals.Colours["antique-white"])
 			return screen
 		}),
 		layout.Stacked(func(gtx C) D {
-			return g.FRect(gtx, []float32{500, 500, 100, 100}, globals.Colours["black"])
+			return G.FRect(gtx, []float32{500, 500, 100, 100}, globals.Colours["black"])
 		}),
 	)
 }

--- a/main.go
+++ b/main.go
@@ -51,6 +51,7 @@ type UI struct {
 	counter       counters.Counter
 	startValue    counters.StartValue
 	unitVal       counters.UnitVal
+	viewer        counters.View
 	geometry      geometry.Geometry
 	jsonFormatter formatters.JsonFormatter
 	topBar        app_layout.TopBar
@@ -125,18 +126,12 @@ func (ui *UI) Layout(gtx C) D {
 				}),
 			)
 		}),
-
-		// Temporarily disabled
-		//layout.Rigid(func(gtx C) D {
-		//	return globals.Inset.Layout(gtx, func(gtx C) D {
-		//		return ui.jsonFormatter.Layout(ui.theme, gtx)
-		//	})
-		//}),
-
-		//layout.Rigid(func(gtx C) D {
-		//	return globals.Inset.Layout(gtx, func(gtx C) D {
-		//		return ui.geometry.Layout(gtx)
-		//	})
-		//}),
-	)
+		layout.Flexed(1, func(gtx C) D {
+			return ui.viewer.Layout(ui.theme, gtx)
+		}),
+		layout.Rigid(func(gtx C) D {
+			return globals.Inset.Layout(gtx, func(gtx C) D {
+				return ui.counter.Layout(ui.theme, gtx)
+			})
+		}))
 }


### PR DESCRIPTION
  - aligned the components in a better manner:
    - the only flexed item (to 1 weight, although it doesn't matter) is the Stack which contains the Viewer
      - Moved the Number displaying functionality outside of the counter component.
        - aka Viewer file, View struct
  - changed layout of controllers so it can be a line of buttons, giving more space to the flexed sibling 
    - need to fix Alignment and layout of the Reset button