### PR TITLE
App Bar - Docking functionality

### DIFF
--- a/apps/counters/counters.go
+++ b/apps/counters/counters.go
@@ -3,10 +3,13 @@ package counters
 import (
 	"gioui-experiment/apps"
 	"gioui-experiment/apps/counters/components/sections"
+	"gioui-experiment/custom_themes/colors"
 	g "gioui-experiment/globals"
 	"gioui.org/layout"
+	"gioui.org/widget"
 	"gioui.org/widget/material"
 	"gioui.org/x/component"
+	"image/color"
 )
 
 type (
@@ -14,8 +17,12 @@ type (
 	D = layout.Dimensions
 
 	Application struct {
-		Top  sections.Top
-		View sections.View
+		Top     sections.Top
+		View    sections.View
+		dockBtn widget.Clickable
+		icon    *widget.Icon
+		btn     material.IconButtonStyle
+		th      *material.Theme
 		*apps.Router
 	}
 )
@@ -27,7 +34,32 @@ func New(router *apps.Router) *Application {
 }
 
 func (app *Application) Actions() []component.AppBarAction {
-	return []component.AppBarAction{}
+	return []component.AppBarAction{
+		{
+			OverflowAction: component.OverflowAction{
+				Tag: &app.dockBtn,
+			},
+			Layout: func(gtx C, bg, fg color.NRGBA) D {
+				if app.dockBtn.Clicked() {
+					app.NonModalDrawer = !app.NonModalDrawer
+				}
+				if app.NonModalDrawer {
+					app.icon = g.LockCLosedIcon
+					app.btn = component.SimpleIconButton(bg, fg, &app.dockBtn, app.icon)
+					app.btn.Background = bg
+					app.btn.Color = g.Colours[colors.DARK_RED]
+					app.Router.NavAnim.Appear(gtx.Now)
+				} else {
+					app.icon = g.LockOpenedIcon
+					app.btn = component.SimpleIconButton(bg, fg, &app.dockBtn, app.icon)
+					app.btn.Background = bg
+					app.btn.Color = g.Colours[colors.SEA_GREEN]
+					app.Router.NavAnim.Disappear(gtx.Now)
+				}
+				return app.btn.Layout(gtx)
+			},
+		},
+	}
 }
 
 func (app *Application) Overflow() []component.OverflowAction {

--- a/apps/editor/editor.go
+++ b/apps/editor/editor.go
@@ -3,9 +3,13 @@ package editor
 import (
 	"gioui-experiment/apps"
 	"gioui-experiment/apps/editor/components"
+	"gioui-experiment/custom_themes/colors"
+	g "gioui-experiment/globals"
 	"gioui.org/layout"
+	"gioui.org/widget"
 	"gioui.org/widget/material"
 	"gioui.org/x/component"
+	"image/color"
 )
 
 type (
@@ -13,7 +17,11 @@ type (
 	D = layout.Dimensions
 
 	Application struct {
-		editor components.TextArea
+		editor  components.TextArea
+		dockBtn widget.Clickable
+		icon    *widget.Icon
+		btn     material.IconButtonStyle
+		th      *material.Theme
 		*apps.Router
 	}
 )
@@ -25,7 +33,32 @@ func New(router *apps.Router) *Application {
 }
 
 func (app *Application) Actions() []component.AppBarAction {
-	return []component.AppBarAction{}
+	return []component.AppBarAction{
+		{
+			OverflowAction: component.OverflowAction{
+				Tag: &app.dockBtn,
+			},
+			Layout: func(gtx C, bg, fg color.NRGBA) D {
+				if app.dockBtn.Clicked() {
+					app.NonModalDrawer = !app.NonModalDrawer
+				}
+				if app.NonModalDrawer {
+					app.icon = g.LockCLosedIcon
+					app.btn = component.SimpleIconButton(bg, fg, &app.dockBtn, app.icon)
+					app.btn.Background = bg
+					app.btn.Color = g.Colours[colors.DARK_RED]
+					app.Router.NavAnim.Appear(gtx.Now)
+				} else {
+					app.icon = g.LockOpenedIcon
+					app.btn = component.SimpleIconButton(bg, fg, &app.dockBtn, app.icon)
+					app.btn.Background = bg
+					app.btn.Color = g.Colours[colors.SEA_GREEN]
+					app.Router.NavAnim.Disappear(gtx.Now)
+				}
+				return app.btn.Layout(gtx)
+			},
+		},
+	}
 }
 
 func (app *Application) Overflow() []component.OverflowAction {

--- a/apps/geography/geography.go
+++ b/apps/geography/geography.go
@@ -2,9 +2,13 @@ package geography
 
 import (
 	"gioui-experiment/apps"
+	"gioui-experiment/custom_themes/colors"
+	g "gioui-experiment/globals"
 	"gioui.org/layout"
+	"gioui.org/widget"
 	"gioui.org/widget/material"
 	"gioui.org/x/component"
+	"image/color"
 )
 
 type (
@@ -12,6 +16,10 @@ type (
 	D = layout.Dimensions
 
 	Application struct {
+		dockBtn widget.Clickable
+		icon    *widget.Icon
+		btn     material.IconButtonStyle
+		th      *material.Theme
 		*apps.Router
 	}
 )
@@ -23,7 +31,32 @@ func New(router *apps.Router) *Application {
 }
 
 func (app *Application) Actions() []component.AppBarAction {
-	return []component.AppBarAction{}
+	return []component.AppBarAction{
+		{
+			OverflowAction: component.OverflowAction{
+				Tag: &app.dockBtn,
+			},
+			Layout: func(gtx C, bg, fg color.NRGBA) D {
+				if app.dockBtn.Clicked() {
+					app.NonModalDrawer = !app.NonModalDrawer
+				}
+				if app.NonModalDrawer {
+					app.icon = g.LockCLosedIcon
+					app.btn = component.SimpleIconButton(bg, fg, &app.dockBtn, app.icon)
+					app.btn.Background = bg
+					app.btn.Color = g.Colours[colors.DARK_RED]
+					app.Router.NavAnim.Appear(gtx.Now)
+				} else {
+					app.icon = g.LockOpenedIcon
+					app.btn = component.SimpleIconButton(bg, fg, &app.dockBtn, app.icon)
+					app.btn.Background = bg
+					app.btn.Color = g.Colours[colors.SEA_GREEN]
+					app.Router.NavAnim.Disappear(gtx.Now)
+				}
+				return app.btn.Layout(gtx)
+			},
+		},
+	}
 }
 
 func (app *Application) Overflow() []component.OverflowAction {

--- a/custom_themes/colors/colors.go
+++ b/custom_themes/colors/colors.go
@@ -1,6 +1,8 @@
 package colors
 
 const (
+	DARK_RED      = "dark-red"
+	SEA_GREEN     = "sea-green"
 	DEEP_SKY_BLUE = "deep-sky-blue"
 	GREY          = "grey"
 	BLACK         = "black"

--- a/globals/icons.go
+++ b/globals/icons.go
@@ -10,6 +10,11 @@ var PlusIcon = func() *widget.Icon {
 	return icon
 }()
 
+var RefreshIcon = func() *widget.Icon {
+	icon, _ := widget.NewIcon(icons.NavigationRefresh)
+	return icon
+}()
+
 var MinusIcon = func() *widget.Icon {
 	icon, _ := widget.NewIcon(icons.ContentRemove)
 	return icon
@@ -20,12 +25,12 @@ var MenuIcon = func() *widget.Icon {
 	return icon
 }()
 
-var RefreshIcon = func() *widget.Icon {
-	icon, _ := widget.NewIcon(icons.NavigationRefresh)
+var LockCLosedIcon = func() *widget.Icon {
+	icon, _ := widget.NewIcon(icons.ActionLock)
 	return icon
 }()
 
-//var CheckedIcon = func() *widget.Icon {
-//	icon, _ := widget.NewIcon(icons.ActionCheckCircle)
-//	return icon
-//}()
+var LockOpenedIcon = func() *widget.Icon {
+	icon, _ := widget.NewIcon(icons.ActionLockOpen)
+	return icon
+}()


### PR DESCRIPTION
  - Adapted App Bar to dock or undock on demand:
    - Using lock/unlock icon to dock/undock
  - Implemented AppBarAction on all Application files
    - This looks pretty redundant: -> to be reimplemented in the future when more AppBar Actions and AppBar Overflows will be added to each Application:
      - There will be cases such as for the Geography Application, where the actions and overflows will be different from the ones on other apps.
      - Contextual Menu to be implemented individually for each page:
        - The only thing in common should be the "Copy" which represents Copy to Clipboard
  - Current Issues:
    - When docking is enabled, tapping on the Menu Icon closes and reopens the menu
      - Unable to close the menu when docking is enabled:
        - !!!!!!!!!!!!!!!!!!!!!!!!
        - Check condition and the order of events assertion on the AppBar!!!!