### PR TITLE
Update Control Panel and add DisplayLayout and Filters UI controllers:

### DIFF
--- a/apps/app.go
+++ b/apps/app.go
@@ -3,6 +3,7 @@ package apps
 import (
 	g "gioui-experiment/globals"
 	"gioui.org/layout"
+	"gioui.org/unit"
 	"gioui.org/widget/material"
 	"gioui.org/x/component"
 	"time"
@@ -95,7 +96,7 @@ func (r *Router) Layout(gtx C, th *material.Theme) D {
 	content := layout.Flexed(1, func(gtx C) D {
 		return layout.Flex{}.Layout(gtx,
 			layout.Rigid(func(gtx C) D {
-				gtx.Constraints.Max.X /= 4
+				gtx.Constraints.Max.X = gtx.Px(unit.Dp(250))
 				return r.NavDrawer.Layout(gtx, th, &r.NavAnim)
 			}),
 			layout.Flexed(1, func(gtx C) D {

--- a/apps/counters/components/controllers/control_panel/display_layout.go
+++ b/apps/counters/components/controllers/control_panel/display_layout.go
@@ -1,0 +1,47 @@
+package control_panel
+
+import (
+	"fmt"
+	"gioui.org/layout"
+	"gioui.org/op"
+	"gioui.org/widget"
+	"gioui.org/widget/material"
+)
+
+type (
+	DisplayLayout struct {
+		radioBtns widget.Enum
+	}
+
+	Unit struct {
+	}
+
+	Table struct {
+	}
+
+	Card struct {
+	}
+)
+
+func (dl *DisplayLayout) Layout(gtx C, th *material.Theme) D {
+	if len(dl.radioBtns.Value) == 0 {
+		dl.radioBtns.Value = "s"
+	}
+	if dl.radioBtns.Changed() {
+		switch dl.radioBtns.Value {
+		case "s":
+			fmt.Println("single")
+		case "g":
+			fmt.Println("grid")
+		case "t":
+			fmt.Println("table")
+		}
+		op.InvalidateOp{}.Add(gtx.Ops)
+	}
+
+	return layout.Flex{Axis: layout.Vertical}.Layout(gtx,
+		layout.Rigid(material.RadioButton(th, &dl.radioBtns, "s", "Single Unit").Layout),
+		layout.Rigid(material.RadioButton(th, &dl.radioBtns, "g", "Grid").Layout),
+		layout.Rigid(material.RadioButton(th, &dl.radioBtns, "t", "Table").Layout),
+	)
+}

--- a/apps/counters/components/controllers/control_panel/filters.go
+++ b/apps/counters/components/controllers/control_panel/filters.go
@@ -1,0 +1,33 @@
+package control_panel
+
+import (
+	"gioui.org/layout"
+	"gioui.org/widget"
+	"gioui.org/widget/material"
+)
+
+type (
+	Filters struct {
+		ascii       widget.Bool
+		binary      widget.Bool
+		octal       widget.Bool
+		hexadecimal widget.Bool
+	}
+)
+
+func (f *Filters) Layout(gtx C, th *material.Theme) D {
+	return layout.Flex{Axis: layout.Vertical}.Layout(gtx,
+		layout.Rigid(func(gtx C) D {
+			return material.CheckBox(th, &f.ascii, "Ascii").Layout(gtx)
+		}),
+		layout.Rigid(func(gtx C) D {
+			return material.CheckBox(th, &f.binary, "Binary").Layout(gtx)
+		}),
+		layout.Rigid(func(gtx C) D {
+			return material.CheckBox(th, &f.octal, "Octal").Layout(gtx)
+		}),
+		layout.Rigid(func(gtx C) D {
+			return material.CheckBox(th, &f.hexadecimal, "Hexadecimal").Layout(gtx)
+		}),
+	)
+}

--- a/apps/counters/components/controllers/panel.go
+++ b/apps/counters/components/controllers/panel.go
@@ -6,6 +6,7 @@ import (
 	g "gioui-experiment/globals"
 	"gioui.org/layout"
 	"gioui.org/unit"
+	"gioui.org/widget"
 	"gioui.org/widget/material"
 	"gioui.org/x/component"
 	"image"
@@ -13,40 +14,105 @@ import (
 
 type (
 	ControlPanel struct {
-		vh       control_panel.ValueHandler
-		inc      control_panel.Incrementor
-		incState component.DiscloserState
-		vhState  component.DiscloserState
+		controllers []Controller
+		list        widget.List
+		vh          control_panel.ValueHandler
+		inc         control_panel.Incrementor
+		display     control_panel.DisplayLayout
+		filters     control_panel.Filters
+
+		/// hardcoded in order to keep track of the specific current state
+		incState     component.DiscloserState
+		vhState      component.DiscloserState
+		displayState component.DiscloserState
+		filtersState component.DiscloserState
+	}
+
+	Controller struct {
+		name   string
+		layout func(C, *Controller) D
 	}
 )
 
 var controllerInset = layout.Inset{
 	Top:    unit.Dp(10),
-	Right:  unit.Dp(20),
+	Right:  unit.Dp(25),
 	Bottom: unit.Dp(10),
-	Left:   unit.Dp(5),
 }
 
 func (cp *ControlPanel) Layout(gtx C, th *material.Theme) D {
-	incControl := layout.Rigid(func(gtx C) D {
-		return component.SimpleDiscloser(th, &cp.incState).Layout(gtx,
-			material.Body1(th, "Manual Incrementors").Layout,
-			func(gtx C) D {
-				return controllerInset.Layout(gtx, func(gtx C) D {
-					return cp.inc.Layout(gtx, th)
-				})
-			})
+	cp.list.Axis = layout.Vertical
+
+	divider := layout.Rigid(func(gtx C) D {
+		div := component.Divider(th)
+		div.Left = unit.Dp(5)
+		div.Right = unit.Dp(5)
+		return div.Layout(gtx)
 	})
 
-	vhControl := layout.Rigid(func(gtx C) D {
-		return component.SimpleDiscloser(th, &cp.vhState).Layout(gtx,
-			material.Body1(th, "Start and Step Values").Layout,
-			func(gtx C) D {
-				return controllerInset.Layout(gtx, func(gtx C) D {
-					return cp.vh.Layout(gtx, th)
+	// every controller is a vertical flex which contains 2 rigids - discloser and the divider
+	cp.controllers = []Controller{
+		{
+			name: "Manual Incrementors",
+			layout: func(gtx C, c *Controller) D {
+				content := layout.Rigid(func(gtx C) D {
+					return component.SimpleDiscloser(th, &cp.incState).Layout(gtx,
+						material.Body1(th, c.name).Layout,
+						func(gtx C) D {
+							return controllerInset.Layout(gtx, func(gtx C) D {
+								return cp.inc.Layout(gtx, th)
+							})
+						})
 				})
-			})
-	})
+				return cp.LayOutset(gtx, content, divider)
+			},
+		},
+		{
+			name: "Start and Step Values",
+			layout: func(gtx C, c *Controller) D {
+				content := layout.Rigid(func(gtx C) D {
+					return component.SimpleDiscloser(th, &cp.vhState).Layout(gtx,
+						material.Body1(th, c.name).Layout,
+						func(gtx C) D {
+							return controllerInset.Layout(gtx, func(gtx C) D {
+								return cp.vh.Layout(gtx, th)
+							})
+						})
+				})
+				return cp.LayOutset(gtx, content, divider)
+			},
+		},
+		{
+			name: "Display Layout",
+			layout: func(gtx C, c *Controller) D {
+				content := layout.Rigid(func(gtx C) D {
+					return component.SimpleDiscloser(th, &cp.displayState).Layout(gtx,
+						material.Body1(th, c.name).Layout,
+						func(gtx C) D {
+							return controllerInset.Layout(gtx, func(gtx C) D {
+								return cp.display.Layout(gtx, th)
+							})
+						})
+				})
+				return cp.LayOutset(gtx, content, divider)
+			},
+		},
+		{
+			name: "Filters",
+			layout: func(gtx C, c *Controller) D {
+				content := layout.Rigid(func(gtx C) D {
+					return component.SimpleDiscloser(th, &cp.filtersState).Layout(gtx,
+						material.Body1(th, c.name).Layout,
+						func(gtx C) D {
+							return controllerInset.Layout(gtx, func(gtx C) D {
+								return cp.filters.Layout(gtx, th)
+							})
+						})
+				})
+				return cp.LayOutset(gtx, content, divider)
+			},
+		},
+	}
 
 	return layout.Stack{Alignment: layout.NW}.Layout(gtx,
 		layout.Expanded(func(gtx C) D {
@@ -55,6 +121,15 @@ func (cp *ControlPanel) Layout(gtx C, th *material.Theme) D {
 		layout.Stacked(func(gtx C) D {
 			containerSize := image.Pt(gtx.Constraints.Max.X, gtx.Constraints.Max.Y)
 			gtx.Constraints = layout.Exact(gtx.Constraints.Constrain(containerSize))
-			return layout.Flex{Axis: layout.Vertical}.Layout(gtx, incControl, vhControl)
+
+			// return a vertical list of (discloser, divider) groups, as ListElements
+			return material.List(th, &cp.list).Layout(gtx, len(cp.controllers), func(gtx C, i int) D {
+				return cp.controllers[i].layout(gtx, &cp.controllers[i])
+			})
 		}))
+}
+
+// LayOutset - wraps the discloser and divider in a vertical flex layout
+func (cp *ControlPanel) LayOutset(gtx C, discloser, divider layout.FlexChild) D {
+	return layout.Flex{Axis: layout.Vertical}.Layout(gtx, discloser, divider)
 }

--- a/apps/counters/components/data/data_handler.go
+++ b/apps/counters/components/data/data_handler.go
@@ -46,9 +46,9 @@ func (gen *Generator) SetActiveSequence(active string) {
 			if len(gen.Cache[k]) == 0 {
 				switch k {
 				case PRIMES:
-					gen.GenPrimes(PLIMIT)
+					gen.genPrimes(PLIMIT)
 				case FIBS:
-					gen.GenFibs(FLIMIT)
+					gen.genFibs(FLIMIT)
 				}
 			}
 		} else {
@@ -70,8 +70,8 @@ func isPrime(n uint64) bool {
 	return true
 }
 
-// GenPrimes - Generate Prime sequence
-func (gen *Generator) GenPrimes(length int) {
+// genPrimes - Generate Prime sequence
+func (gen *Generator) genPrimes(length int) {
 	if len(gen.Cache[PRIMES]) == 0 {
 		gen.Cache[PRIMES] = make([]uint64, length)
 		gen.Cache[PRIMES][0] = 2
@@ -105,7 +105,7 @@ func (gen *Generator) GenPrimes(length int) {
 	//}
 }
 
-func GetFibByIndex(n uint64) uint64 {
+func getFibByIndex(n uint64) uint64 {
 	if n <= 1 {
 		return n
 	}
@@ -116,13 +116,13 @@ func GetFibByIndex(n uint64) uint64 {
 	return n2 + n1
 }
 
-// GenFibs - Generate Fibonacci sequence
-func (gen *Generator) GenFibs(length int) {
+// genFibs - Generate Fibonacci sequence
+func (gen *Generator) genFibs(length int) {
 	if len(gen.Cache[FIBS]) == 0 {
 		gen.Cache[FIBS] = make([]uint64, length)
 		index := uint64(0)
 		for i := range gen.Cache[FIBS] {
-			gen.Cache[FIBS][i] = GetFibByIndex(index)
+			gen.Cache[FIBS][i] = getFibByIndex(index)
 			index++
 		}
 	}

--- a/apps/counters/components/sections/viewer.go
+++ b/apps/counters/components/sections/viewer.go
@@ -9,6 +9,7 @@ import (
 	"gioui.org/layout"
 	"gioui.org/unit"
 	"gioui.org/widget/material"
+	"gioui.org/x/component"
 	"image"
 	"strconv"
 )
@@ -46,6 +47,10 @@ func (v *View) Layout(gtx C, th *material.Theme) D {
 		})
 	})
 
+	divider := layout.Rigid(func(gtx C) D {
+		return component.Divider(th).Layout(gtx)
+	})
+
 	size := image.Pt(gtx.Constraints.Max.X, gtx.Constraints.Max.Y)
 	return layout.Flex{
 		Axis: layout.Horizontal,
@@ -75,6 +80,7 @@ func (v *View) Layout(gtx C, th *material.Theme) D {
 				}),
 			)
 		}),
+		divider,
 		controlPanel,
 	)
 }

--- a/apps/counters/counters.go
+++ b/apps/counters/counters.go
@@ -29,13 +29,9 @@ type (
 )
 
 func New(router *apps.Router) *Application {
-	counterApp := &Application{
+	return &Application{
 		Router: router,
 	}
-
-	// TODO: add dynamic handling for the diclosers
-	//counterApp.View.ControlPanel.InitControllers()
-	return counterApp
 }
 
 func (app *Application) Actions() []component.AppBarAction {


### PR DESCRIPTION
- Changed ControlPanel to handle all Controllers as ListElements, belonging to a vertical list
  - The reason for this is to trigger vertical scrolling in case the content of all opened disclosers gets to large for the Constraints.Max.Y of the Control Panel layout
  - Added a Controller struct which contains a string, name and a function, named layout 
  - ControlPanel struct contains all the layouts of the control_panel components, plus the discloser state for all of them, individually
    - The reason for this is to keep track of jthe state separately, by isolating the DiscloserState components form each other
  - Added a divider component which is always displayed below the current control_panel component
  - Added a small LayOutset function to wrap the discloser and divider for all control_panel components
- Added UI for Dislpay Layout and Filters sections
  - Display Layout refers to the way the displayedNumber(s) is/are displayed
    - There are 3 options:
      - Single Unit (default value), displays only the current number
      - Grid, which will display the numbers as cards, containing relevant info about the current number
        - This will make more sense after the Filters controller gets implemented
      - Table, which will display the numbers in a tabular form, allowing the user to add/remove columns.
        - Again, This will make sense after the Filters controller gets implemented. One Filter added = One Column added, and the other way around
  - Filters refers to adding variations of the current number:
    - Currently only 4 options were added:
      - Ascii, which will convert the current number to ascii (if applicable, else it will be a null based element on the grid card, or table cell
      - Binary, which will convert the current number to binary
      - Octal, which will reflect the current's number octal value
      - Hexadecimal, which will refer to the hexadecimal value of the current number
- Hardcoded the drawer modal, in case docking is enabled. It was set to 250 DP, since when on wider screens, the dynamic resize gets to be way too large 
- Renamed several function from the data_handler to preserve encapsulation