### PR TITLE
Fix BG Theme color issue

### DIFF
--- a/apps/counters/components/controllers/sequence_handler.go
+++ b/apps/counters/components/controllers/sequence_handler.go
@@ -31,8 +31,7 @@ func (sh *SequenceHandler) Layout(gtx C, th *material.Theme) D {
 		}
 		return custom_widgets.LabeledIconBtn{
 			Theme:      th,
-			BgColor:    g.Colours[color.DEEP_SKY_BLUE],
-			LabelColor: g.Colours[color.BLACK],
+			LabelColor: g.Colours[color.WHITE],
 			Button:     &sh.toWhole,
 			Label:      "Z",
 			Icon:       nil,
@@ -44,8 +43,7 @@ func (sh *SequenceHandler) Layout(gtx C, th *material.Theme) D {
 		}
 		return custom_widgets.LabeledIconBtn{
 			Theme:      th,
-			BgColor:    g.Colours[color.DEEP_SKY_BLUE],
-			LabelColor: g.Colours[color.BLACK],
+			LabelColor: g.Colours[color.WHITE],
 			Button:     &sh.toNatural,
 			Label:      "N",
 			Icon:       nil,
@@ -57,8 +55,7 @@ func (sh *SequenceHandler) Layout(gtx C, th *material.Theme) D {
 		}
 		return custom_widgets.LabeledIconBtn{
 			Theme:      th,
-			BgColor:    g.Colours[color.DEEP_SKY_BLUE],
-			LabelColor: g.Colours[color.BLACK],
+			LabelColor: g.Colours[color.WHITE],
 			Button:     &sh.toPrime,
 			Label:      "Primes",
 			Icon:       nil,
@@ -70,8 +67,7 @@ func (sh *SequenceHandler) Layout(gtx C, th *material.Theme) D {
 		}
 		return custom_widgets.LabeledIconBtn{
 			Theme:      th,
-			BgColor:    g.Colours[color.DEEP_SKY_BLUE],
-			LabelColor: g.Colours[color.BLACK],
+			LabelColor: g.Colours[color.WHITE],
 			Button:     &sh.toFib,
 			Label:      "Fibs",
 			Icon:       nil,

--- a/apps/editor/components/viewer.go
+++ b/apps/editor/components/viewer.go
@@ -16,9 +16,8 @@ type (
 )
 
 type TextArea struct {
-	field      widget.Editor
-	border     widget.Border
-	isDisabled bool
+	field  widget.Editor
+	border widget.Border
 }
 
 func (ta *TextArea) Layout(gtx C, th *material.Theme) D {
@@ -26,7 +25,6 @@ func (ta *TextArea) Layout(gtx C, th *material.Theme) D {
 	input.SelectionColor = g.Colours[color.TEXT_SELECTION]
 	ta.field.SingleLine = false
 	ta.field.Alignment = text.Start
-	ta.isDisabled = false
 
 	textArea := layout.Flexed(1, func(gtx C) D {
 		border := widget.Border{

--- a/custom_themes/colors/colors.go
+++ b/custom_themes/colors/colors.go
@@ -5,6 +5,7 @@ const (
 	SEA_GREEN     = "sea-green"
 	DEEP_SKY_BLUE = "deep-sky-blue"
 	GREY          = "grey"
+	WHITE         = "white"
 	BLACK         = "black"
 	ANTIQUE_WHITE = "antique-white"
 	AERO_BLUE     = "aero-blue"

--- a/custom_widgets/labeled_icon_widget.go
+++ b/custom_widgets/labeled_icon_widget.go
@@ -10,35 +10,26 @@ import (
 	"image/color"
 )
 
-// LabeledIconBtn - component which returns a custom-made widget, based on its given properties
 type LabeledIconBtn struct {
-	Theme               *material.Theme
-	BgColor, LabelColor color.NRGBA
-	Button              *widget.Clickable
-	Icon                *widget.Icon
-	Label               string
+	Theme      *material.Theme
+	LabelColor color.NRGBA
+	Button     *widget.Clickable
+	Icon       *widget.Icon
+	Label      string
 }
 
-// Layout - currently returns a button-like widget, which contains:
-// an icon on the left side and a text label n the right side.
-// These 2 are separated by 5 device pixels
 func (lib LabeledIconBtn) Layout(gtx layout.Context) layout.Dimensions {
-
-	// Set custom colours for Icon and Label
 	// Set the TextSize for the Label
-	lib.Theme.Palette.ContrastBg = lib.BgColor
 	lib.Theme.TextSize.Scale(14.0 / 16.0)
 
 	// return a ButtonLayout dimension which contains the Icon and Label
 	return material.ButtonLayout(lib.Theme, lib.Button).Layout(gtx, func(gtx layout.Context) layout.Dimensions {
 		return layout.UniformInset(globals.DefaultMargin).Layout(gtx, func(gtx layout.Context) layout.Dimensions {
 
-			// labeledIcon will be used to return all its content dimensions
 			labeledIcon := layout.Flex{
 				Axis:      layout.Horizontal,
 				Alignment: layout.Middle,
 			}
-			// spacer is used for separating the Icon from the Label by an amount of pixels
 			spacer := unit.Dp(5)
 			// This is the actual Icon of the Button. It will return the dimensions of the Icon widget
 			layIcon := layout.Rigid(func(gtx layout.Context) layout.Dimensions {

--- a/main.go
+++ b/main.go
@@ -36,9 +36,9 @@ func Run(w *app.Window) error {
 	th := material.NewTheme(gofont.Collection())
 
 	router := application.NewRouter()
-	router.Register(0, counters.New(&router))
 	router.Register(1, editor.New(&router))
-	router.Register(2, geography.New(&router))
+	router.Register(2, counters.New(&router))
+	router.Register(3, geography.New(&router))
 
 	for event := range w.Events() {
 		switch event := event.(type) {


### PR DESCRIPTION
Fix BG Theme color issue:
  - Whenever the Counter app was reached, and any widget was hovered, the contrast of the app was set to a lighter blue
    - Fixed by removing the contrast.bg coloring on labeled_icon_widget.go
      - This specific custom widget will be removed in the future anyway
    - Removed the bgColor property from the LabeledIconBtn struct to prevent the issue from happening in the future
    - Removed some gibberish comments since the functionality is obvious
    - Some small fixes over the editor app
      - Removed the active boolean from the TextArea struct, since it's being handled by the graphics context